### PR TITLE
Update spree_globalize.gemspec

### DIFF
--- a/spree_globalize.gemspec
+++ b/spree_globalize.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.has_rdoc = false
+  #s.has_rdoc = false
 
   s.add_runtime_dependency 'friendly_id-globalize'
   s.add_runtime_dependency 'globalize'


### PR DESCRIPTION
Resolvendo deprecated spree_globalize rdoc.